### PR TITLE
ci: add release and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,12 @@
-name: Validate
+name: Publish
 
-on: [pull_request]
+on:
+  release:
+    types: [created]
 
 jobs:
-  validate:
+  validate_and_publish:
+    name: Validate and Publish
     runs-on: ubuntu-latest
 
     steps:
@@ -17,7 +20,12 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Symlink Local Dependencies
-        run: yarn lerna bootstrap --hoist
+        run: yarn lerna bootstrap
 
       - name: Build, Lint, Test
-        run: yarn validate
+        run: yarn run validate
+
+      - name: Pubish Release
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: yarn lerna publish --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,108 @@
+name: Release
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  validate_and_release:
+    name: Validate and Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Yarn
+        if: ${{ env.ACT }}
+        run: npm install yarn -g
+
+      - name: Install Dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Symlink Local Dependencies
+        run: yarn lerna bootstrap
+
+      - name: Build, Lint, Test
+        run: yarn run validate
+
+      - name: Upload Coverage - Shared
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./packages/shared/coverage/lcov.info
+          flags: shared
+          name: shared
+          fail_ci_if_error: false
+
+      - name: Delay between coverage uploads
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'
+
+      - name: Upload Coverage - Server
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./packages/server/coverage/lcov.info
+          flags: server
+          name: server
+          fail_ci_if_error: false
+
+      - name: Delay between coverage uploads
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'
+
+      - name: Upload Coverage - Joiful
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./packages/joiful/coverage/lcov.info
+          flags: joiful
+          name: joiful
+          fail_ci_if_error: false
+
+      - name: Delay between coverage uploads
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'
+
+      - name: Upload Coverage - Express
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./packages/express/coverage/lcov.info
+          flags: express
+          name: express
+          fail_ci_if_error: false
+
+      - name: Delay between coverage uploads
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'
+
+      - name: Upload Coverage - Client
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./packages/client/coverage/lcov.info
+          flags: client
+          name: client
+          fail_ci_if_error: false
+
+      - name: Delay between coverage uploads
+        uses: jakejarvis/wait-action@master
+        with:
+          time: '1s'
+
+      - name: Upload Coverage - React
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./packages/react/coverage/lcov.info
+          flags: react
+          name: react
+          fail_ci_if_error: false
+
+      - name: Create Release
+        run: yarn release

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "prebuild": "yarn run clean",
     "validate-imports": "ts-node ./support/validateImports.ts",
     "validate": "yarn validate-imports && lerna run validate",
-    "release": "yarn lerna version --conventional-commits"
+    "release": "yarn lerna version --conventional-commits --yes"
   },
   "devDependencies": {
     "@types/bluebird": "3.5.29",


### PR DESCRIPTION
### Add Release and Publish workflows
- Add GitHub Actions workflows for
  - Cutting a release on push to master. Analyses commit history, updates change log, bumps packages and commits back into master.
  - Publishing a new version on tagging a release