### PR TITLE
ci: fix symlink issue with release and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Symlink Local Dependencies
-        run: yarn lerna bootstrap
+        run: yarn lerna bootstrap --hoist
 
       - name: Build, Lint, Test
         run: yarn run validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Symlink Local Dependencies
-        run: yarn lerna bootstrap
+        run: yarn lerna bootstrap --hoist
 
       - name: Build, Lint, Test
         run: yarn run validate


### PR DESCRIPTION
### Fix Symlink issue with Release and Publish workflows
- `yarn lerna boostrap` was missing the `--hoist` flag in these workflows